### PR TITLE
Out-of-bounds atom indices in bond table

### DIFF
--- a/src/main/C/common/reaccsio.c
+++ b/src/main/C/common/reaccsio.c
@@ -352,11 +352,11 @@ int ReadREACCSBond(Fortran_FILE *fp, struct reaccs_bond_t *bp)
       nitems = MAX_BONDLINE_FIELDS;
    for (i = 0; i < nitems; ++i)
    {
-      pos = i * 3;
+      pos = i * BONDLINE_FIELD_LEN;
       memset(buffer, 0, BONDLINE_FIELD_LEN + 1);
       n_chars = bond_line_len - pos;
-      if (n_chars > 3)
-         n_chars = 3;
+      if (n_chars > BONDLINE_FIELD_LEN)
+         n_chars = BONDLINE_FIELD_LEN;
       for (j = 0, k = 0; j < n_chars; ++j)
       {
          c = fp->buffer[pos + j];

--- a/src/main/C/common/reaccsio.c
+++ b/src/main/C/common/reaccsio.c
@@ -330,26 +330,17 @@ int ReadREACCSBond(Fortran_FILE *fp, struct reaccs_bond_t *bp)
    if (fp->status != FORTRAN_NORMAL) return(fp->status);
 
    strncpy(buffer,fp->buffer,MAX_BUFFER);
-   /* zero pad only atom numbers! */
-   for (i=0; i<6; i++) if (buffer[i] == ' ') buffer[i] = '0';
 
    bp->stereo_symbol = 0;
    bp->dummy = 0;
    bp->topography = 0;
    bp->reaction_mark = NONE;
-   // make sure spaces are interpreted the Fortran-way
-   for (i=9; i<strlen(buffer)  &&  i<21; i+=3)
-   {
-       if ((i+1)<strlen(buffer)  &&  buffer[i+1]==' ') buffer[i+1] = '0';
-       if ((i+2)<strlen(buffer)  &&  buffer[i+2]==' ') buffer[i+2] = '0';
-   }
    nitems = sscanf(buffer,
                    "%3d%3d%3d%3d%3d%3d%3d",
                    &bp->atoms[0],   &bp->atoms[1],
                    &bp->bond_type,  &bp->stereo_symbol,
                    &bp->dummy,
                    &bp->topography, &bp->reaction_mark);
-
    if (nitems >= 3)
    {
       GetBuffer(fp);

--- a/src/main/C/programs/struchk.c
+++ b/src/main/C/programs/struchk.c
@@ -1581,6 +1581,22 @@ int RunStruchk(struct reaccs_molecule_t **mpp, struct data_line_t *data_list)
 
    if ((result & SIZE_CHECK_FAILED) == 0)
    {
+      for (i = 0; i < mp->n_bonds; ++i) {
+         for (j = 0; j < 2; ++j) {
+            if (mp->bond_array[i].atoms[j] < 1 || mp->bond_array[i].atoms[j] > mp->n_atoms)
+            {
+               snprintf(msg_buffer, MAXMSG,
+                  "%10s    : illegal atom # (%d, max allowed is %d) in bond %d",
+                  mp->name, mp->bond_array[i].atoms[j], mp->n_atoms, i + 1);
+               AddMsgToList(msg_buffer);
+               result |= SIZE_CHECK_FAILED;
+            }
+         }
+      }
+   }
+
+   if ((result & SIZE_CHECK_FAILED) == 0)
+   {
       if (convert_atom_texts)
       {
          tmp = ConvertAtomAliases(mp);


### PR DESCRIPTION
@rohdebe1
Currently out-of-bounds atom indices in bond table cause a segmentation fault due to unallocated memory being accessed on write.
To avoid the problem I have added a check in `struchk.c` for such out-of-bounds atom indices.
Specifically, I incurred into the segfault when parsing the following misaligned CTAB:
```

     RDKit          2D

  3  2  0  0  0  0  0  0  0  0999 V2000
    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    1.2990    0.7500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
    2.5981   -0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
 1  2  1  0
  2  3  1  0
M  END
```
Due to zero padding taking place in `reaccsio.c`, the atom indices in the first misaligned bond line were being parsed as `10` and `20`, respectively.
While the 1st line is misaligned, it can be read correctly if zero padding is not performed. Zero padding is actually unnecessary as `sscanf` will simply skip spaces.